### PR TITLE
feat: add support for compile from source via env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,20 @@ All render functions accept these options:
 
 Full documentation is available at [hexdocs.pm/typst](https://hexdocs.pm/typst).
 
+## Building from Source
+
+When you add this package to your `mix.exs` dependencies, it will by default
+attempt to use precompiled Rustler assets. To override this behaviour, add
+`{:rustler, ">= 0.0.0"}` to your `mix.exs`, and set the environment variable
+`TYPST_BUILD=true`. Alternatively, you can put the following in your
+`config.exs`:
+
+```elixir
+config :rustler_precompiled, :force_build, typst: true
+```
+
+Building from source requires a rust toolchain of at least version `1.92.0`.
+
 ## Cutting a new release
 
 * Make the code changes

--- a/lib/typst_nif.ex
+++ b/lib/typst_nif.ex
@@ -20,6 +20,7 @@ defmodule Typst.NIF do
     base_url: "#{github_url}/releases/download/v#{version}",
     nif_versions: ["2.15", "2.17"],
     mode: mode,
+    force_build: System.get_env("TYPST_BUILD") in ["1", "true"],
     target: System.get_env("RUSTLER_TARGET")
 
   def compile_pdf(_content, _root_dir, _font_paths, _assets, _cache_fonts),


### PR DESCRIPTION
This adds support for the `TYPST_BUILD` env var to force the NIF to build locally. I also updated the README with a compile from source guide. 

This is useful for me to force a build when updating a project to use the `custom-eex-engine`, branch but without modifying my `config.exs`