### PR TITLE
Add `:pdf_standards` option to `render_to_pdf/3` for PDF/A compliance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `:pdf_standards` option to `render_to_pdf/3` for PDF/A compliance (e.g. `"a-2b"`, `"a-4"`). Thank you [adrian-mihai-olaru](https://github.com/adrian-mihai-olaru).
+
 ## [v0.3.4] - 2026-04-14
 
 ### Added

--- a/lib/typst.ex
+++ b/lib/typst.ex
@@ -66,6 +66,7 @@ defmodule Typst do
     * `:pdf_standards` - a list of PDF standard strings to comply with. Supported values:
       `"a-1a"`, `"a-1b"`, `"a-2a"`, `"a-2b"`, `"a-2u"`, `"a-3a"`, `"a-3b"`, `"a-3u"`,
       `"a-4"`, `"a-4e"`, `"a-4f"`. Defaults to `[]` (no specific standard).
+      An unknown value returns `{:error, "unknown PDF standard: ..."}`.
 
   ## Examples
 

--- a/lib/typst.ex
+++ b/lib/typst.ex
@@ -84,7 +84,7 @@ defmodule Typst do
     extra_fonts = Keyword.get(opts, :extra_fonts, []) ++ @embedded_fonts
     root_dir = Keyword.get(opts, :root_dir, ".")
     cache_fonts = Keyword.get(opts, :cache_fonts, true)
-    pdf_standards = Keyword.get(opts, :pdf_standards, [])
+    pdf_opts = %Typst.NIF.PdfOptions{standards: Keyword.get(opts, :pdf_standards, [])}
 
     assets =
       Keyword.get(opts, :assets, [])
@@ -93,7 +93,7 @@ defmodule Typst do
     trim = Keyword.get(opts, :trim, false)
     markup = render_to_string(typst_markup, bindings, trim: trim)
 
-    Typst.NIF.compile_pdf(markup, root_dir, extra_fonts, assets, cache_fonts, pdf_standards)
+    Typst.NIF.compile_pdf(markup, root_dir, extra_fonts, assets, cache_fonts, pdf_opts)
   end
 
   @spec render_to_pdf!(String.t(), list(formattable()), list(typst_opt())) :: binary()

--- a/lib/typst.ex
+++ b/lib/typst.ex
@@ -42,6 +42,7 @@ defmodule Typst do
           | {:assets, Keyword.t() | map() | list({String.t(), binary()})}
           | {:trim, boolean()}
           | {:cache_fonts, boolean()}
+          | {:pdf_standards, list(String.t())}
 
   @spec render_to_pdf(String.t(), list(formattable()), list(typst_opt())) ::
           {:ok, binary()} | {:error, String.t()}
@@ -62,6 +63,10 @@ defmodule Typst do
 
     * `:cache_fonts` - when `true`, caches scanned fonts across calls. Defaults to `true`.
 
+    * `:pdf_standards` - a list of PDF standard strings to comply with. Supported values:
+      `"a-1a"`, `"a-1b"`, `"a-2a"`, `"a-2b"`, `"a-2u"`, `"a-3a"`, `"a-3b"`, `"a-3u"`,
+      `"a-4"`, `"a-4e"`, `"a-4f"`. Defaults to `[]` (no specific standard).
+
   ## Examples
 
       iex> {:ok, pdf} = Typst.render_to_pdf("= test\\n<%= name %>", name: "John")
@@ -78,6 +83,7 @@ defmodule Typst do
     extra_fonts = Keyword.get(opts, :extra_fonts, []) ++ @embedded_fonts
     root_dir = Keyword.get(opts, :root_dir, ".")
     cache_fonts = Keyword.get(opts, :cache_fonts, true)
+    pdf_standards = Keyword.get(opts, :pdf_standards, [])
 
     assets =
       Keyword.get(opts, :assets, [])
@@ -86,7 +92,7 @@ defmodule Typst do
     trim = Keyword.get(opts, :trim, false)
     markup = render_to_string(typst_markup, bindings, trim: trim)
 
-    Typst.NIF.compile_pdf(markup, root_dir, extra_fonts, assets, cache_fonts)
+    Typst.NIF.compile_pdf(markup, root_dir, extra_fonts, assets, cache_fonts, pdf_standards)
   end
 
   @spec render_to_pdf!(String.t(), list(formattable()), list(typst_opt())) :: binary()

--- a/lib/typst_nif.ex
+++ b/lib/typst_nif.ex
@@ -1,6 +1,11 @@
 defmodule Typst.NIF do
   @moduledoc false
 
+  defmodule PdfOptions do
+    @moduledoc false
+    defstruct standards: []
+  end
+
   mix_config =
     Mix.Project.config()
 
@@ -22,7 +27,7 @@ defmodule Typst.NIF do
     mode: mode,
     target: System.get_env("RUSTLER_TARGET")
 
-  def compile_pdf(_content, _root_dir, _font_paths, _assets, _cache_fonts, _pdf_standards),
+  def compile_pdf(_content, _root_dir, _font_paths, _assets, _cache_fonts, _pdf_opts),
     do: :erlang.nif_error(:nif_not_loaded)
 
   def compile_png(_content, _root_dir, _font_paths, _pixels_per_pt, _assets, _cache_fonts),

--- a/lib/typst_nif.ex
+++ b/lib/typst_nif.ex
@@ -22,7 +22,7 @@ defmodule Typst.NIF do
     mode: mode,
     target: System.get_env("RUSTLER_TARGET")
 
-  def compile_pdf(_content, _root_dir, _font_paths, _assets, _cache_fonts),
+  def compile_pdf(_content, _root_dir, _font_paths, _assets, _cache_fonts, _pdf_standards),
     do: :erlang.nif_error(:nif_not_loaded)
 
   def compile_png(_content, _root_dir, _font_paths, _pixels_per_pt, _assets, _cache_fonts),

--- a/native/typst_nif/src/lib.rs
+++ b/native/typst_nif/src/lib.rs
@@ -307,7 +307,7 @@ fn parse_pdf_standard(s: &str) -> Result<PdfStandard, String> {
         "a-4" | "4" => Ok(PdfStandard::A_4),
         "a-4e" | "4e" => Ok(PdfStandard::A_4e),
         "a-4f" | "4f" => Ok(PdfStandard::A_4f),
-        other => Err(format!("unknown PDF standard: {:?}", other)),
+        other => Err(format!("unknown PDF standard: {}", other)),
     }
 }
 

--- a/native/typst_nif/src/lib.rs
+++ b/native/typst_nif/src/lib.rs
@@ -15,7 +15,7 @@ use typst::text::{Font, FontBook};
 use typst::utils::LazyHash;
 use typst::{Library, LibraryExt};
 use typst_kit::fonts::{FontSlot, Fonts};
-use typst_pdf::PdfOptions;
+use typst_pdf::{PdfOptions, PdfStandard, PdfStandards};
 
 struct CachedFonts {
     key: Vec<String>,
@@ -294,6 +294,23 @@ fn http_successful(status: u16) -> bool {
     status / 100 == 2
 }
 
+fn parse_pdf_standard(s: &str) -> Result<PdfStandard, String> {
+    match s {
+        "a-1a" | "1a" => Ok(PdfStandard::A_1a),
+        "a-1b" | "1b" => Ok(PdfStandard::A_1b),
+        "a-2a" | "2a" => Ok(PdfStandard::A_2a),
+        "a-2b" | "2b" => Ok(PdfStandard::A_2b),
+        "a-2u" | "2u" => Ok(PdfStandard::A_2u),
+        "a-3a" | "3a" => Ok(PdfStandard::A_3a),
+        "a-3b" | "3b" => Ok(PdfStandard::A_3b),
+        "a-3u" | "3u" => Ok(PdfStandard::A_3u),
+        "a-4" | "4" => Ok(PdfStandard::A_4),
+        "a-4e" | "4e" => Ok(PdfStandard::A_4e),
+        "a-4f" | "4f" => Ok(PdfStandard::A_4f),
+        other => Err(format!("unknown PDF standard: {:?}", other)),
+    }
+}
+
 #[rustler::nif(schedule = "DirtyCpu")]
 fn compile_pdf<'a>(
     env: Env<'a>,
@@ -302,6 +319,7 @@ fn compile_pdf<'a>(
     extra_fonts: Vec<String>,
     assets: Vec<(String, Binary<'a>)>,
     cache_fonts: bool,
+    pdf_standards: Vec<String>,
 ) -> Result<Term<'a>, String> {
     let world = TypstNifWorld::new(root_dir, markup, extra_fonts, cache_fonts);
 
@@ -317,8 +335,20 @@ fn compile_pdf<'a>(
 
     comemo::evict(0);
 
-    let pdf_bytes =
-        typst_pdf::pdf(&document, &PdfOptions::default()).map_err(|e| format!("{:#?}", e))?;
+    let options = if pdf_standards.is_empty() {
+        PdfOptions::default()
+    } else {
+        let standards: Vec<PdfStandard> = pdf_standards
+            .iter()
+            .map(|s| parse_pdf_standard(s))
+            .collect::<Result<Vec<_>, _>>()?;
+        PdfOptions {
+            standards: PdfStandards::new(&standards),
+            ..PdfOptions::default()
+        }
+    };
+
+    let pdf_bytes = typst_pdf::pdf(&document, &options).map_err(|e| format!("{:#?}", e))?;
 
     let mut binary = NewBinary::new(env, pdf_bytes.len());
     binary.copy_from_slice(pdf_bytes.as_slice());

--- a/native/typst_nif/src/lib.rs
+++ b/native/typst_nif/src/lib.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::{Arc, LazyLock, Mutex};
 
-use rustler::{Binary, Env, NewBinary, Term};
+use rustler::{Binary, Env, NewBinary, NifStruct, Term};
 use typst::diag::{
     eco_format, FileError, FileResult, PackageError, PackageResult, SourceDiagnostic,
 };
@@ -294,6 +294,12 @@ fn http_successful(status: u16) -> bool {
     status / 100 == 2
 }
 
+#[derive(NifStruct)]
+#[module = "Typst.NIF.PdfOptions"]
+struct PdfOpts {
+    standards: Vec<String>,
+}
+
 fn parse_pdf_standard(s: &str) -> Result<PdfStandard, String> {
     match s {
         "a-1a" | "1a" => Ok(PdfStandard::A_1a),
@@ -319,7 +325,7 @@ fn compile_pdf<'a>(
     extra_fonts: Vec<String>,
     assets: Vec<(String, Binary<'a>)>,
     cache_fonts: bool,
-    pdf_standards: Vec<String>,
+    pdf_opts: PdfOpts,
 ) -> Result<Term<'a>, String> {
     let world = TypstNifWorld::new(root_dir, markup, extra_fonts, cache_fonts);
 
@@ -335,10 +341,11 @@ fn compile_pdf<'a>(
 
     comemo::evict(0);
 
-    let options = if pdf_standards.is_empty() {
+    let options = if pdf_opts.standards.is_empty() {
         PdfOptions::default()
     } else {
-        let standards: Vec<PdfStandard> = pdf_standards
+        let standards: Vec<PdfStandard> = pdf_opts
+            .standards
             .iter()
             .map(|s| parse_pdf_standard(s))
             .collect::<Result<Vec<_>, _>>()?;

--- a/native/typst_nif/src/lib.rs
+++ b/native/typst_nif/src/lib.rs
@@ -343,7 +343,7 @@ fn compile_pdf<'a>(
             .map(|s| parse_pdf_standard(s))
             .collect::<Result<Vec<_>, _>>()?;
         PdfOptions {
-            standards: PdfStandards::new(&standards),
+            standards: PdfStandards::new(&standards).map_err(|e| format!("{}", e))?,
             ..PdfOptions::default()
         }
     };

--- a/test/typst_test.exs
+++ b/test/typst_test.exs
@@ -55,6 +55,23 @@ defmodule TypstTest do
     end
   end
 
+  describe "pdf_standards" do
+    test "produces a valid PDF when a standard is specified" do
+      markup = ~S"""
+      #set document(date: datetime(year: 2026, month: 1, day: 1))
+      = hello
+      """
+
+      {:ok, pdf} = Typst.render_to_pdf(markup, [], pdf_standards: ["a-2b"])
+      assert <<37, 80, 68, 70, 45, _rest::binary>> = pdf
+    end
+
+    test "returns an error on unknown standard" do
+      assert {:error, "unknown PDF standard: a-9z"} =
+               Typst.render_to_pdf("= hello", [], pdf_standards: ["a-9z"])
+    end
+  end
+
   describe "errors" do
     test "error message on invalid template" do
       template = ~S"#image("


### PR DESCRIPTION
## Summary

Adds an optional `:pdf_standards` option to `render_to_pdf/3` that allows specifying PDF/A compliance standards (e.g., PDF/A-2b).

## Changes

- Add `:pdf_standards` option to `render_to_pdf/3` accepting a list of standard strings (`"a-1a"`, `"a-2b"`, `"a-4"`, etc.)
- Update the Rust NIF (`compile_pdf`) to accept and parse PDF standards, passing them to `typst_pdf::PdfOptions`
- `PdfStandards::new` returns a `Result` — errors are properly propagated

## Backwards Compatibility

Fully backwards compatible. The option defaults to `[]` (empty list), which uses `PdfOptions::default()` — identical to the previous behavior. All existing tests pass without changes.